### PR TITLE
Updating package to have compatibility with Laravel 5.3 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # ExpBackoffWorker
 
 
-Adds automatic exponential backoff with default delay of 30 seconds and max delay of 2 hours to Laravel 5.0 queue worker. 
+Adds automatic exponential backoff with default delay of 30 seconds and max delay of 2 hours to Laravel 5.3+ queue worker.
 
 
 How to Install
 ---------------
 
-### Laravel 5.0
+### Laravel 5.3+
 
 1.  Install the `deboorn/expbackoffworker` package
 
@@ -19,10 +19,10 @@ How to Install
 
     ```php
     # Add `QueueServiceProvider` to the `providers` array
-    'providers' => array(
+    'providers' => [
         ...
-        'ExpBackoffWorker\QueueServiceProvider',
-    )
+        ExpBackoffWorker\QueueServiceProvider::class,
+    ]
     ```
 3. Update `config/queue.php` to increase redis.expire to max delay + 100
 

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     }
   ],
   "require": {
-    "php": ">=5.3.0",
-    "illuminate/support": "5.*"
+    "php": ">=5.6.4",
+    "illuminate/support": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*"
   },
   "autoload": {
     "psr-4": {

--- a/src/QueueServiceProvider.php
+++ b/src/QueueServiceProvider.php
@@ -1,20 +1,21 @@
 <?php namespace ExpBackoffWorker;
 
 use Illuminate\Queue\QueueServiceProvider as IlluminateQueueServiceProvider;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 
-class QueueServiceProvider extends IlluminateQueueServiceProvider {
-
-	protected function registerWorker()
-	{
-		$this->registerWorkCommand();
-
-		$this->registerRestartCommand();
-
-		$this->app->singleton('queue.worker', function($app)
-		{
-			return new Worker($app['queue'], $app['queue.failer'], $app['events']);
-		});
-	}
-
-
+class QueueServiceProvider extends IlluminateQueueServiceProvider
+{
+    /**
+     * Register the queue worker.
+     *
+     * @return void
+     */
+    protected function registerWorker()
+    {
+        $this->app->singleton('queue.worker', function () {
+            return new Worker(
+                $this->app['queue'], $this->app['events'], $this->app[ExceptionHandler::class]
+            );
+        });
+    }
 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -2,44 +2,32 @@
 
 use Exception;
 use Illuminate\Queue\Worker as IlluminateQueueWorker;
-use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\WorkerOptions;
 
 class Worker extends IlluminateQueueWorker
 {
-
-    public function process($connection, Job $job, $maxTries = 0, $delay = 0)
+    /**
+     * Handle an exception that occurred while the job was running.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  \Illuminate\Queue\WorkerOptions  $options
+     * @param  \Exception  $e
+     * @return void
+     *
+     * @throws \Exception
+     */
+    protected function handleJobException($connectionName, $job, WorkerOptions $options, $e)
     {
-        if ($maxTries > 0 && $job->attempts() > $maxTries) {
-            return $this->logFailedJob($connection, $job);
-        }
+        // Add exponential delay based on the job attempts and the provided delay seconds.
+        // The delay will default to 30 seconds by default or when delay is set to zero.
+        // A max delay of 2 hours will be used when exponential delay exceeds 2 hours
+        // Example of delay in seconds: 30, 60, 90, 180, ... 7200
+        $options->delay = $options->delay ?: 30;
+        $options->delay = $job->attempts() > 1 ? (pow(2, $job->attempts() - 2) * $options->delay) : 0;
+        $maxDelay = 60 * 60 * 2;
+        if ($options->delay > $maxDelay) $options->delay = $maxDelay;
 
-        try {
-            // First we will fire off the job. Once it is done we will see if it will
-            // be auto-deleted after processing and if so we will go ahead and run
-            // the delete method on the job. Otherwise we will just keep moving.
-            $job->fire();
-
-            return ['job' => $job, 'failed' => false];
-        } catch (Exception $e) {
-            // If we catch an exception, we will attempt to release the job back onto
-            // the queue so it is not lost. This will let is be retried at a later
-            // time by another listener (or the same one). We will do that here.
-            if (!$job->isDeleted()) {
-
-                // Add exponential delay based on the job attempts and the provided delay seconds.
-                // The delay will default to 30 seconds by default or when delay is set to zero.
-                // A max delay of 2 hours will be used when exponential delay exceeds 2 hours
-                // Example of delay in seconds: 30, 60, 90, 180, ... 7200
-                $delay = $delay ?: 30;
-                $delay = $job->attempts() > 1 ? (pow(2, $job->attempts() - 2) * $delay) : 0;
-                $maxDelay = 60 * 60 * 2;
-                if ($delay > $maxDelay) $delay = $maxDelay;
-
-                $job->release($delay);
-            }
-
-            throw $e;
-        }
+        parent::handleJobException($connectionName, $job, $options, $e);
     }
-
 }


### PR DESCRIPTION
## Summary

This fixes https://github.com/deboorn/expbackoffworker/issues/1 by making the package compatible with versions 5.3 and above of the Laravel/Lumen framework. Some docs are also updated. The refactoring done should make it easier to maintain compatibility as future Laravel versions arise, due to calling the parent method of a class we're extending when possible.

## What Changed

As noted in that issue, version 5.3 introduced a new definition of the process method, which abstracted some logic out of the `process()` method and into other methods. In our case, this package is primarily overriding the job exception handler, adding a delay, so we no longer need to override the process method.

Instead, we can override the `handleJobException()` method which is called when an exception happens on a job. The delay math remains the same as before, but now we are modifying the worker options, changing the delay. We then call the original Worker class's `handleJobException()` method, which releases the job back onto the queue with our new delay.

The service provider was also updated to match the current service provider.

### Breaking Changes

This is not backwards compatible with Laravel 5.2 and below, so a new major version is required.

Additionally, the version selector in `composer.json` was updated to follow best practices for including Illuminate packages, as compatibility with future versions of Laravel is not guaranteed. This means that once a new Laravel version is released, this package will need to have the composer.json updated to include the new Laravel version, which means for a short time it may prevent people who use this package from upgrading. I believe this, while more tedious, is safer to ensure compatibility and prevent cases of someone installing the package and learning it's not compatible since the method definition changed.

## Testing

I have tested this on a Laravel 5.6 project manually and it works as expected. I have verified that the queue `Worker` class has not had any breaking changes between 5.3 and 5.7, so it should be compatible from 5.3 up.