### PR TITLE
Refactoring to make logic testable, fixing install documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+phpunit.xml
+vendor

--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ How to Install
         ExpBackoffWorker\QueueServiceProvider::class,
     ]
     ```
-3. Update `config/queue.php` to increase redis.expire to max delay + 100
+3. Update `config/queue.php` to increase {queue-driver}.retry_after to max delay + 100, such as redis.retry_after
 
     ```php
 		'redis' => [
 		    ...
-			'expire' => 7300,
+			'retry_after' => 7300,
 		],
-    
     ```

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,20 @@
   ],
   "require": {
     "php": ">=5.6.4",
+    "illuminate/queue": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
     "illuminate/support": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "~6.0"
   },
   "autoload": {
     "psr-4": {
       "ExpBackoffWorker\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
     }
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         verbose="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/GetDelay.php
+++ b/src/GetDelay.php
@@ -1,0 +1,42 @@
+<?php namespace ExpBackoffWorker;
+
+class GetDelay
+{
+    private $maxDelay;
+    private $defaultDelay;
+
+    /**
+     * GetDelay constructor
+     *
+     * @param  int  $maxDelay      Maximum delay for a job (default 7200)
+     * @param  int  $defaultDelay  Default initial job delay
+     */
+    public function __construct($maxDelay = 7200, $defaultDelay = 30)
+    {
+        $this->maxDelay = $maxDelay;
+        $this->defaultDelay = $defaultDelay;
+    }
+
+    /**
+     * Add exponential delay based on the job attempts and the provided delay seconds.
+     * The delay will default to 30 seconds by default or when delay is set to zero.
+     * A max delay of 2 hours will be used when exponential delay exceeds 2 hours
+     * Example of delay in seconds: 30, 60, 120, 240, ... 7200
+     *
+     * @param  int  $workerDelay    The delay from the WorkerOptions object
+     * @param  int  $attemptsCount  How many attempts there have been so far on the job
+     * @return int
+     */
+    public function __invoke($workerDelay, $attemptsCount)
+    {
+        $delay = $workerDelay ?: $this->defaultDelay;
+        if ($attemptsCount > 1) {
+            // 2^(attempts-2) * delay
+            $delay = 2 ** ($attemptsCount - 2) * $delay;
+        } else {
+            // First attempt always gets a delay of 0
+            $delay = 0;
+        }
+        return min($delay, $this->maxDelay);
+    }
+}

--- a/src/GetDelay.php
+++ b/src/GetDelay.php
@@ -9,7 +9,7 @@ class GetDelay
      * GetDelay constructor
      *
      * @param  int  $maxDelay      Maximum delay for a job (default 7200)
-     * @param  int  $defaultDelay  Default initial job delay
+     * @param  int  $defaultDelay  Default job delay multiplier if worker delay is 0
      */
     public function __construct($maxDelay = 7200, $defaultDelay = 30)
     {

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1,6 +1,5 @@
 <?php namespace ExpBackoffWorker;
 
-use Exception;
 use Illuminate\Queue\Worker as IlluminateQueueWorker;
 use Illuminate\Queue\WorkerOptions;
 
@@ -19,14 +18,7 @@ class Worker extends IlluminateQueueWorker
      */
     protected function handleJobException($connectionName, $job, WorkerOptions $options, $e)
     {
-        // Add exponential delay based on the job attempts and the provided delay seconds.
-        // The delay will default to 30 seconds by default or when delay is set to zero.
-        // A max delay of 2 hours will be used when exponential delay exceeds 2 hours
-        // Example of delay in seconds: 30, 60, 90, 180, ... 7200
-        $options->delay = $options->delay ?: 30;
-        $options->delay = $job->attempts() > 1 ? (pow(2, $job->attempts() - 2) * $options->delay) : 0;
-        $maxDelay = 60 * 60 * 2;
-        if ($options->delay > $maxDelay) $options->delay = $maxDelay;
+        $options->delay = (new GetDelay)($options->delay, $job->attempts());
 
         parent::handleJobException($connectionName, $job, $options, $e);
     }

--- a/tests/GetDelayTest.php
+++ b/tests/GetDelayTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use ExpBackoffWorker\GetDelay;
+
+class GetDelayTest extends TestCase
+{
+    public function test_exponential_backoff_defaults()
+    {
+        $maxDelay = 7200;
+        $getDelay = new GetDelay;
+
+        $delays = [0, 30, 60, 120, 240, 480, 960, 1920, 3840, $maxDelay, $maxDelay];
+
+        foreach ($delays as $attempt => $expectedDelay) {
+            $delay = $getDelay(0, ++$attempt);
+            $this->assertEquals($expectedDelay, $delay, "Attempt $attempt");
+        }
+    }
+
+    public function test_exponential_backoff_custom_maxdelay()
+    {
+        $maxDelay = 3600;
+        $defaultDelay = 15;
+        $getDelay = new GetDelay($maxDelay, $defaultDelay);
+
+        $delays = [0, 15, 30, 60, 120, 240, 480, 960, 1920, $maxDelay, $maxDelay];
+
+        foreach ($delays as $attempt => $expectedDelay) {
+            $delay = $getDelay(0, ++$attempt);
+            $this->assertEquals($expectedDelay, $delay, "Attempt $attempt");
+        }
+    }
+
+    public function test_exponential_backoff_custom_workerdelay()
+    {
+        $maxDelay = 3600;
+        $defaultDelay = 30;
+        $getDelay = new GetDelay($maxDelay, $defaultDelay);
+
+        $delays = [0, 15, 30, 60, 120, 240, 480, 960, 1920, $maxDelay, $maxDelay];
+
+        foreach ($delays as $attempt => $expectedDelay) {
+            $delay = $getDelay(15, ++$attempt);
+            $this->assertEquals($expectedDelay, $delay, "Attempt $attempt");
+        }
+    }
+}


### PR DESCRIPTION
This PR does two things:

First, it [updates the install documentation](https://github.com/EricTendian/expbackoffworker/commit/4ae1c6d76dbbc0fa137bf2576369bfa013734ca0) to account for the [rename](https://github.com/laravel/laravel/commit/fd569a3785b116a9ca37b75c779ba24bec189b67) of the queue config's `expire` field to `retry_after`. I unfortunately missed this in #2.

Secondly, this refactors the actual math involved out into an Invokable class, so it's easier to read and test. I've added a couple unit tests to verify it was doing what was expected. I noticed that the sequence `Example of delay in seconds: 30, 60, 90, 180, ... 7200` in the comment associated with the logic originally would never actually occur with the formula coded, so I updated that sequence to match what the formula actually uses.

There's no breaking changes here as the formula and default values remain the same, it's just formatted differently.