### PR TITLE
Adding standard open source documentation based on template package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,14 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
 root = true
 
 [*]
 charset = utf-8
+indent_size = 4
+indent_style = space
 end_of_line = lf
 insert_final_newline = true
-indent_style = space
-indent_size = 4
 trim_trailing_whitespace = true
 
 [*.md]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/.scrutinizer.yml   export-ignore
+/tests              export-ignore
+/docs               export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
+build
 composer.lock
-phpunit.xml
 vendor

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,23 @@
+filter:
+    excluded_paths: [tests/*]
+
+checks:
+    php:
+        remove_extra_empty_lines: true
+        remove_php_closing_tag: true
+        remove_trailing_whitespace: true
+        fix_use_statements:
+            remove_unused: true
+            preserve_multiple: false
+            preserve_blanklines: true
+            order_alphabetically: true
+        fix_php_opening_tag: true
+        fix_linefeed: true
+        fix_line_ending: true
+        fix_identation_4spaces: true
+        fix_doc_comments: true
+
+tools:
+    external_code_coverage:
+        timeout: 600
+        runs: 3

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,1 @@
+preset: psr2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+dist: trusty
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+
+# This triggers builds to run on the new TravisCI infrastructure.
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+## Cache composer
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+  include:
+    - php: 5.6
+      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+
+before_script:
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
+
+script:
+  - vendor/bin/phpcs --standard=psr2 src/
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+
+after_script:
+  - |
+    if [[ "$TRAVIS_PHP_VERSION" != '7.0' ]]; then
+      wget https://scrutinizer-ci.com/ocular.phar
+      php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+    fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to `expbackoffworker` will be documented in this file.
+
+Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
+
+## [2.1.0] - 2018-11-DD
+
+### Added
+- Unit tests
+- Contribution-related documentation
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Moved logic for the exponential backoff calculation into a separate
+  class for easier testing and updated to use builtin PHP operators
+- Documentation for how to install the package
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
+## [2.0.0] - 2018-11-02
+
+### Added
+- Compatibility with Laravel 5.3 and above
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Nothing
+
+### Removed
+- Compatibility with Laravel 5.0 thru 5.2 (use 1.0.0 instead)
+
+### Security
+- Nothing
+
+## [1.0.0] - 2015-10-02
+
+### Added
+- Initial version of this package for use with Laravel 5.0 thru 5.2
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Nothing
+
+### Removed
+- Nothing
+
+### Security
+- Nothing

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at `daniel.boorn[at]gmail.com`. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+We accept contributions via Pull Requests on [Github](https://github.com/deboorn/expbackoffworker).
+
+
+## Pull Requests
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - Check the code style with ``$ composer check-style`` and fix it with ``$ composer fix-style``.
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
+
+- **Create feature branches** - Don't ask us to pull from your master branch.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+
+
+## Running Tests
+
+``` bash
+$ composer test
+```
+
+
+**Happy coding**!

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!-- Provide a general summary of the issue in the Title above -->
+
+## Detailed description
+
+Provide a detailed description of the change or addition you are proposing.
+
+Make it clear if the issue is a bug, an enhancement or just a question.
+
+## Context
+
+Why is this change important to you? How would you use it?
+
+How can it benefit other users?
+
+## Possible implementation
+
+Not obligatory, but suggest an idea for implementing addition or change.
+
+## Your environment
+
+Include as many relevant details about the environment you experienced the bug in and how to reproduce it.
+
+* Version used (e.g. PHP 7.2):
+* Operating system and version (e.g. Ubuntu 18.04, Windows 10):
+* Link to your project:
+* ...
+* ...

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+
+Describe your changes in detail.
+
+## Motivation and context
+
+Why is this change required? What problem does it solve?
+
+If it fixes an open issue, please link to the issue here (if you write `fixes #num`
+or `closes #num`, the issue will be automatically closed when the pull is accepted.)
+
+## How has this been tested?
+
+Please describe in detail how you tested your changes.
+
+Include details of your testing environment, and the tests you ran to
+see how your change affects other areas of the code, etc.
+
+## Types of changes
+
+What types of changes does your code introduce? Put an `x` in all the boxes that apply:
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+
+Go over all the following points, and put an `x` in all the boxes that apply.
+
+Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).
+
+- [ ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
+- [ ] My pull request addresses exactly one patch/feature.
+- [ ] I have created a branch for this patch/feature.
+- [ ] Each individual commit in the pull request is meaningful.
+- [ ] I have added tests to cover my changes.
+- [ ] If my change requires a change to the documentation, I have updated it accordingly.
+
+If you're unsure about any of these, don't hesitate to ask. We're here to help!

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # ExpBackoffWorker
 
+[![Latest Version on Packagist][ico-version]][link-packagist]
+[![Software License][ico-license]](LICENSE)
+[![Build Status][ico-travis]][link-travis]
+[![Coverage Status][ico-scrutinizer]][link-scrutinizer]
+[![Quality Score][ico-code-quality]][link-code-quality]
+[![Total Downloads][ico-downloads]][link-downloads]
 
 Adds automatic exponential backoff with default delay of 30 seconds and max delay of 2 hours to Laravel 5.3+ queue worker.
 
-
-How to Install
----------------
+## Install
 
 ### Laravel 5.3+
 
-1.  Install the `deboorn/expbackoffworker` package
+1.  Install the `deboorn/expbackoffworker` package via Composer
 
     ```shell
     $ composer require deboorn/expbackoffworker
@@ -24,11 +28,57 @@ How to Install
         ExpBackoffWorker\QueueServiceProvider::class,
     ]
     ```
+
 3. Update `config/queue.php` to increase {queue-driver}.retry_after to max delay + 100, such as redis.retry_after
 
     ```php
-		'redis' => [
-		    ...
-			'retry_after' => 7300,
-		],
+        # Update `retry_after` for the queue connection you plan to use
+        'redis' => [
+              ...
+            'retry_after' => 7300,
+        ],
     ```
+
+## Change log
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
+
+## Testing
+
+``` bash
+$ composer test
+```
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) for details.
+
+## Security
+
+If you discover any security related issues, please email daniel.boorn [at] gmail.com instead of using the issue tracker.
+
+## Credits
+
+- [Daniel Boorn][link-author]
+- [Eric Tendian][link-contributor]
+- [All Contributors][link-contributors]
+
+## License
+
+The Apache 2.0 License (Apache-2.0). Please see [License File](LICENSE) for more information.
+
+[ico-version]: https://img.shields.io/packagist/v/deboorn/expbackoffworker.svg?style=flat-square
+[ico-license]: https://img.shields.io/github/license/deboorn/expbackoffworker.svg?style=flat-square
+[ico-travis]: https://img.shields.io/travis/deboorn/expbackoffworker/master.svg?style=flat-square
+[ico-scrutinizer]: https://img.shields.io/scrutinizer/coverage/g/deboorn/expbackoffworker.svg?style=flat-square
+[ico-code-quality]: https://img.shields.io/scrutinizer/g/deboorn/expbackoffworker.svg?style=flat-square
+[ico-downloads]: https://img.shields.io/packagist/dt/deboorn/expbackoffworker.svg?style=flat-square
+
+[link-packagist]: https://packagist.org/packages/deboorn/expbackoffworker
+[link-travis]: https://travis-ci.org/deboorn/expbackoffworker
+[link-scrutinizer]: https://scrutinizer-ci.com/g/deboorn/expbackoffworker/code-structure
+[link-code-quality]: https://scrutinizer-ci.com/g/deboorn/expbackoffworker
+[link-downloads]: https://packagist.org/packages/deboorn/expbackoffworker
+[link-author]: https://github.com/deboorn
+[link-contributor]: https://github.com/EricTendian
+[link-contributors]: ../../contributors

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,44 @@
 {
-  "name": "deboorn/expbackoffworker",
-  "description": "Adds automatic exponential backoff to Laravel 5's queue worker",
-  "keywords": ["exponential", "backoff", "laravel"],
-  "homepage": "https://github.com/deboorn/expbackoffworker",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Daniel Boorn",
-      "email": "daniel.boorn@gmail.com"
+    "name": "deboorn/expbackoffworker",
+    "description": "Adds automatic exponential backoff to Laravel 5's queue worker",
+    "keywords": ["exponential", "backoff", "laravel"],
+    "homepage": "https://github.com/deboorn/expbackoffworker",
+    "license": "Apache-2",
+    "authors": [
+        {
+            "name": "Daniel Boorn",
+            "email": "daniel.boorn@gmail.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.6.4",
+        "illuminate/queue": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
+        "illuminate/support": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~6.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "ExpBackoffWorker\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
+        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    },
+    "config": {
+        "sort-packages": true
     }
-  ],
-  "require": {
-    "php": ">=5.6.4",
-    "illuminate/queue": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
-    "illuminate/support": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "~6.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "ExpBackoffWorker\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Tests\\": "tests/"
-    }
-  }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
          backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="vendor/autoload.php"
          colors="true"
+         verbose="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         verbose="true"
->
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/</directory>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>


### PR DESCRIPTION
To make it clearer how future contributions should be made, and to conform with other leading PHP open source projects, I wanted to add a couple markdown files this repo is currently missing. All these changes were made using https://github.com/thephpleague/skeleton as a template.

There's some CI-related config files in here - I think it would be nice if we had CI setup on this repo now that there's tests, but it's not an absolute requirement.

I think these changes may help encourage more contributions as there's now lots of standard files people expect.