### PR TITLE
Add support for Laravel 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -18,7 +17,7 @@ cache:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.0
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `expbackoffworker` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [3.0.0] - 2021-08-01
+
+### Added
+- Compatibility with Laravel 8
+
+### Removed
+- Compatibility with Laravel 5 and 6 _(use `2.X.X` instead)_
+- Compatibility with PHP 5.6 _(officially; it was broken already)_
+
 ## [2.1.0] - 2019-06-06
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/queue": "8.*",
-        "illuminate/support": "8.*"
+        "illuminate/queue": "^8.0",
+        "illuminate/support": "^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0"

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
-        "illuminate/queue": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.*",
-        "illuminate/support": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.*"
+        "php": ">=7.0",
+        "illuminate/queue": "8.*",
+        "illuminate/support": "8.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0"

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -11,14 +11,14 @@ class Worker extends IlluminateQueueWorker
      * @param  string  $connectionName
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @param  \Illuminate\Queue\WorkerOptions  $options
-     * @param  \Exception  $e
+     * @param  \Throwable  $e
      * @return void
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
     protected function handleJobException($connectionName, $job, WorkerOptions $options, $e)
     {
-        $options->delay = (new GetDelay)($options->delay, $job->attempts());
+        $options->backoff = (new GetDelay)($options->backoff, $job->attempts());
 
         parent::handleJobException($connectionName, $job, $options, $e);
     }


### PR DESCRIPTION
## Description

Laravel 8 changes the `IlluminateQueueWorker` `delay` property to `backoff` and makes minor changes to `IlluminateQueueServiceProvider#registerWorker`, so this package is incompatible with Laravel 8 right now. The existing `(new GetDelay)(...)` syntax also doesn't parse in PHP 5.6, so I officially bumped the minimum PHP version to `7.0` and updated changelog accordingly.

## Motivation and context

I'd like to use this package alongside Laravel 8.

---

**Note:** I think it's technically possible to maintain full backwards compatibility by doing version checks, but that doesn't seem like worthwhile for how stable this package is. For example:

```php
app()->version() // => "6.20.30"
```


## How has this been tested?

I'm on Ubuntu 20.04 and using PHP 7.4.

1. Ran `XDEBUG_MODE=coverage composer test`
2. In my Laravel 8 app I did `php artisan tinker` and `Queue::push(new BackoffTestJob())` and saw the following logs...

```php
class BackoffTestJob extends Job
{
    public function handle()
    {
        Log::info('BackoffTestJob executing... ', ['time' => now()->toISOString()]);
        throw new \Exception('oops');
    }
}
```

```
BackoffTestJob executing... 2021-08-01T06:46:15.446947Z
BackoffTestJob executing... 2021-08-01T06:46:15.523456Z
BackoffTestJob executing... 2021-08-01T06:46:45.493881Z
BackoffTestJob executing... 2021-08-01T06:47:45.610087Z
BackoffTestJob executing... 2021-08-01T06:49:46.319706Z
```
## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ ] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
